### PR TITLE
Fix auth success redirect

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -63,8 +63,8 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Redirigir a la página principal con un parámetro de éxito
-    return NextResponse.redirect(`${requestUrl.origin}?auth_success=true`)
+    // Redirigir a la página de autenticación con un parámetro de éxito
+    return NextResponse.redirect(`${requestUrl.origin}/auth?auth_success=true`)
   } catch (error) {
     console.error("Error inesperado en callback:", error)
     return NextResponse.redirect(`${requestUrl.origin}/auth?error=unexpected`)


### PR DESCRIPTION
## Summary
- redirect auth callback to `/auth?auth_success=true`
- preserve success toast trigger on the auth page

## Testing
- `npx jest` *(fails: EHOSTUNREACH)*