### PR TITLE
Fix cva jest mock export

### DIFF
--- a/__mocks__/cva-mock.js
+++ b/__mocks__/cva-mock.js
@@ -1,2 +1,8 @@
-module.exports = () => () => ""
-module.exports.variants = () => ({})
+const cva = () => () => ""
+cva.variants = () => ({})
+
+module.exports = {
+  __esModule: true,
+  default: cva,
+  cva,
+}


### PR DESCRIPTION
## Summary
- fix `class-variance-authority` mock to correctly export `cva`

## Testing
- `npx jest __tests__/components/tag-badge.test.tsx --runInBand` *(fails: network access blocked for installing jest)*