### PR TITLE
Fix failing expectation in StoryCard test

### DIFF
--- a/__tests__/components/story-card.test.tsx
+++ b/__tests__/components/story-card.test.tsx
@@ -46,8 +46,8 @@ describe("StoryCard Component", () => {
   it("displays author and industry information", () => {
     render(<StoryCard story={mockStory} />)
 
-    expect(screen.getByText(/Por: TestAuthor/)).toBeInTheDocument()
-    expect(screen.getByText(/Industria: Tecnología/)).toBeInTheDocument()
+    expect(screen.getByText(/TestAuthor/)).toBeInTheDocument()
+    expect(screen.getByText(/Tecnología/)).toBeInTheDocument()
   })
 
   it("renders tags when provided", () => {


### PR DESCRIPTION
## Summary
- update author and industry text matchers in the StoryCard test

## Testing
- `npm run lint` *(fails: next not found)*