### PR TITLE
Fix cva mock

### DIFF
--- a/__mocks__/cva-mock.js
+++ b/__mocks__/cva-mock.js
@@ -1,6 +1,5 @@
 const cva = () => () => ""
 cva.variants = () => ({})
-
 module.exports = {
   __esModule: true,
   default: cva,


### PR DESCRIPTION
## Summary
- clean up `cva-mock.js` to prevent Jest syntax error

## Testing
- `npx jest __tests__/components/header.test.tsx --runInBand --no-cache` *(fails: EHOSTUNREACH during pnpm install)*