### PR TITLE
Add book link to top navigation

### DIFF
--- a/__tests__/components/header.test.tsx
+++ b/__tests__/components/header.test.tsx
@@ -42,6 +42,7 @@ describe("Header Component", () => {
     // Verificar que los enlaces de navegación estén presentes
     expect(screen.getByText("Historias")).toBeInTheDocument()
     expect(screen.getByText("Sobre nosotros")).toBeInTheDocument()
+    expect(screen.getByText("Mi libro: RENUNCIO")).toBeInTheDocument()
   })
 
   it("renders login buttons when user is not authenticated", () => {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -69,6 +69,14 @@ export default function Header() {
           <Link href="/sobre-nosotros" className="text-sm font-medium transition-colors hover:text-primary">
             Sobre nosotros
           </Link>
+          <Link
+            href="https://www.galernaweb.com/productos/renuncio-eliana-bracciaforte/?utm_source=cronicaslaborales&utm_medium=topmenu&utm_campaign=renuncio"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium transition-colors hover:text-primary"
+          >
+            Mi libro: RENUNCIO
+          </Link>
           {session && (
             <Link href="/dashboard" className="text-sm font-medium transition-colors hover:text-primary">
               Panel


### PR DESCRIPTION
## Summary
- add link to RENUNCIO book in top menu
- check for the link in the header tests

## Testing
- `npx jest` *(fails: request to registry.npmjs.org/jest failed: connect EHOSTUNREACH)*