### PR TITLE
Fix Google login redirect

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -63,8 +63,8 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Redirigir a la página de autenticación con un parámetro de éxito
-    return NextResponse.redirect(`${requestUrl.origin}/auth?auth_success=true`)
+    // Redirigir al homepage después de la autenticación exitosa
+    return NextResponse.redirect(`${requestUrl.origin}/`)
   } catch (error) {
     console.error("Error inesperado en callback:", error)
     return NextResponse.redirect(`${requestUrl.origin}/auth?error=unexpected`)


### PR DESCRIPTION
## Summary
- redirect successful auth to homepage instead of the login page

## Testing
- `npx jest` *(fails: EHOSTUNREACH)*