### PR TITLE
Fix jest setup recursion

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -17,8 +17,6 @@ Object.defineProperty(window, "matchMedia", {
   })),
 })
 
-// Mock para Next.js router
-jest.mock("next/navigation", () => require("./__mocks__/next-navigation-mock.js"))
 
 // Mock para el proveedor de Supabase
 jest.mock("@/lib/supabase-provider", () => ({


### PR DESCRIPTION
## Summary
- remove next/navigation mock from Jest setup to avoid recursion

## Testing
- `npx jest __tests__/components/header.test.tsx --runInBand` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683b227cf2ec832780fac0744edee997