### PR TITLE
Fix SubmitForm test mocks

### DIFF
--- a/__mocks__/radix-mock.js
+++ b/__mocks__/radix-mock.js
@@ -1,9 +1,23 @@
+const React = require("react")
+
+/**
+ * Creates a very simple mock component that renders a basic DOM element
+ * preserving props and children. Radix UI components are heavily styled and
+ * rely on complex behaviours which we don't need during tests. Rendering them
+ * as plain <div> elements keeps the DOM structure predictable while avoiding
+ * implementation details.
+ */
+const createMockComponent = (element = "div") =>
+  React.forwardRef(({ children, ...props }, ref) =>
+    React.createElement(element, { ref, ...props }, children),
+  )
+
 module.exports = new Proxy(
   {},
   {
-    get: () =>
-      new Proxy(() => {}, {
-        get: () => () => ({}),
-      }),
+    get: (target, prop) => {
+      if (prop === "__esModule") return true
+      return createMockComponent()
+    },
   },
 )

--- a/__tests__/components/submit-form.test.tsx
+++ b/__tests__/components/submit-form.test.tsx
@@ -64,9 +64,12 @@ describe("SubmitForm", () => {
     render(<SubmitForm tags={mockTags} />)
 
     // Completar los campos obligatorios
-    fireEvent.change(screen.getByLabelText(/Título/i), {
-      target: { value: "Mi historia tóxica" },
-    })
+    fireEvent.change(
+      screen.getByPlaceholderText("Dale a tu historia un título impactante"),
+      {
+        target: { value: "Mi historia tóxica" },
+      },
+    )
 
     // Seleccionar industria (esto es más complejo con el componente Select de shadcn)
     // En un caso real, podríamos necesitar adaptar esto según cómo funciona el componente
@@ -78,9 +81,12 @@ describe("SubmitForm", () => {
     fireEvent.click(industryOption)
 
     // Completar el contenido
-    fireEvent.change(screen.getByLabelText(/Tu Historia/i), {
-      target: { value: "Contenido de la historia..." },
-    })
+    fireEvent.change(
+      screen.getByPlaceholderText("Comparte tu experiencia..."),
+      {
+        target: { value: "Contenido de la historia..." },
+      },
+    )
 
     // Enviar el formulario
     fireEvent.click(screen.getByText("Enviar Historia"))


### PR DESCRIPTION
## Summary
- improve Radix mock to output basic DOM elements
- update submit-form test to use placeholders instead of labels

## Testing
- `pnpm exec jest __tests__/components/submit-form.test.tsx` *(fails: command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b2244aeec83279bf4d158ea4edc23