### PR TITLE
Fix Jest setup recursion error

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -18,7 +18,8 @@ Object.defineProperty(window, "matchMedia", {
 })
 
 // Mock para Next.js router
-jest.mock("next/navigation", () => require("./__mocks__/next-navigation-mock.js"))
+import nextNavigationMock from "./__mocks__/next-navigation-mock.js"
+jest.mock("next/navigation", () => nextNavigationMock)
 
 // Mock para el proveedor de Supabase
 jest.mock("@/lib/supabase-provider", () => ({


### PR DESCRIPTION
## Summary
- load the next/navigation mock once in `jest.setup.js`

## Testing
- `npx jest __tests__/components/header.test.tsx -t "Header Component" --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68404d36853c8327850e286ca434e721