### PR TITLE
Fix TagBadge tests

### DIFF
--- a/__tests__/components/tag-badge.test.tsx
+++ b/__tests__/components/tag-badge.test.tsx
@@ -1,21 +1,35 @@
+import type React from "react"
 import { render, screen } from "@testing-library/react"
 import { TagBadge } from "@/components/tag-badge"
 
+// Mock de next/link para simplificar el DOM en pruebas
+jest.mock("next/link", () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  )
+})
+
 describe("TagBadge", () => {
   test("renderiza correctamente el nombre de la etiqueta", () => {
-    render(<TagBadge name="Acoso" />)
+    render(<TagBadge tag={{ id: "acoso", name: "Acoso" }} />)
     expect(screen.getByText("Acoso")).toBeInTheDocument()
   })
 
-  test("aplica la clase de tamaño correcta", () => {
-    const { container } = render(<TagBadge name="Discriminación" size="sm" />)
-    // Verificamos que el elemento tenga la clase de tamaño pequeño
-    expect(container.firstChild).toHaveClass("text-xs")
+  test("enlaza hacia la página correcta", () => {
+    render(<TagBadge tag={{ id: "123", name: "Discriminación" }} />)
+    const link = screen.getByRole("link")
+    expect(link).toHaveAttribute("href", "/tags/123")
   })
 
-  test("aplica la variante correcta", () => {
-    const { container } = render(<TagBadge name="Mobbing" variant="outline" />)
-    // Verificamos que el elemento tenga la clase de variante outline
-    expect(container.firstChild).toHaveClass("border")
+  test("aplica las clases de estilo por defecto", () => {
+    const { container } = render(<TagBadge tag={{ id: "1", name: "Mobbing" }} />)
+    const badge = container.querySelector("div")
+    expect(badge).toHaveClass(
+      "bg-purple-800",
+      "text-purple-100",
+      "hover:bg-purple-700",
+      "border-purple-700",
+      "cursor-pointer"
+    )
   })
 })


### PR DESCRIPTION
## Summary
- update TagBadge tests to use the actual API
- verify default classes and href

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404d4bfdbc83278a6314a422216a0f