### PR TITLE
Fix Next.js navigation mock

### DIFF
--- a/__mocks__/next-navigation-mock.js
+++ b/__mocks__/next-navigation-mock.js
@@ -1,5 +1,3 @@
-const jest = require("jest-mock")
-
 module.exports = {
   useRouter: () => ({
     push: jest.fn(),


### PR DESCRIPTION
## Summary
- remove duplicate jest import from navigation mock

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68409cad2dd88327b600b97dd98beebe