### PR TITLE
Fix submit form select test

### DIFF
--- a/__tests__/components/submit-form.test.tsx
+++ b/__tests__/components/submit-form.test.tsx
@@ -2,6 +2,25 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { SubmitForm } from "@/components/submit-form"
 import { submitStory } from "@/lib/actions"
 
+// Mock del componente Select de shadcn para pruebas
+jest.mock("@/components/ui/select", () => {
+  const React = require("react")
+  const SelectContext = React.createContext(null)
+  const Select = ({ onValueChange, children }: any) => (
+    <SelectContext.Provider value={onValueChange}>
+      <div>{children}</div>
+    </SelectContext.Provider>
+  )
+  const SelectTrigger = ({ children }: any) => <button>{children}</button>
+  const SelectValue = ({ placeholder }: any) => <span>{placeholder}</span>
+  const SelectContent = ({ children }: any) => <div>{children}</div>
+  const SelectItem = ({ children, value }: any) => {
+    const onValueChange = React.useContext(SelectContext)
+    return <div onClick={() => onValueChange?.(value)}>{children}</div>
+  }
+  return { Select, SelectTrigger, SelectValue, SelectContent, SelectItem }
+})
+
 // Mock de las dependencias
 jest.mock("@/lib/actions", () => ({
   submitStory: jest.fn(),


### PR DESCRIPTION
## Summary
- mock `@/components/ui/select` in submit form tests so the industry field renders

## Testing
- `pnpm exec jest __tests__/components/submit-form.test.tsx -t envía el formulario correctamente cuando todos los campos están completos --runInBand` *(fails: command not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409f026e0483278e3e933dfc98508b