### PR TITLE
Redirect to original page after login

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: NextRequest) {
   const code = requestUrl.searchParams.get("code")
   const error = requestUrl.searchParams.get("error")
   const errorDescription = requestUrl.searchParams.get("error_description")
+  const next = requestUrl.searchParams.get("next") || "/"
 
   // Si hay un error en la URL, redirigir a la página de error
   if (error) {
@@ -63,8 +64,8 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Redirigir a la página de autenticación con un parámetro de éxito
-    return NextResponse.redirect(`${requestUrl.origin}/auth?auth_success=true`)
+    // Redirigir al destino original o a la página principal por defecto
+    return NextResponse.redirect(`${requestUrl.origin}${next}`)
   } catch (error) {
     console.error("Error inesperado en callback:", error)
     return NextResponse.redirect(`${requestUrl.origin}/auth?error=unexpected`)

--- a/components/auth-form.tsx
+++ b/components/auth-form.tsx
@@ -25,10 +25,12 @@ export function AuthForm() {
   const handleGoogleSignIn = async () => {
     try {
       setIsLoading(true)
+      const next = `${window.location.pathname}${window.location.search}`
+      const redirectUrl = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`
       await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: `${window.location.origin}/auth/callback`,
+          redirectTo: redirectUrl,
         },
       })
     } catch (error) {
@@ -47,10 +49,12 @@ export function AuthForm() {
 
     try {
       setIsLoading(true)
+      const next = `${window.location.pathname}${window.location.search}`
+      const redirectUrl = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`
       const { data, error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          emailRedirectTo: redirectUrl,
           // Asegurarse de que se creen usuarios nuevos si no existen
           shouldCreateUser: true,
         },
@@ -94,10 +98,12 @@ export function AuthForm() {
   const handleResendLink = async () => {
     try {
       setIsLoading(true)
+      const next = `${window.location.pathname}${window.location.search}`
+      const redirectUrl = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          emailRedirectTo: redirectUrl,
           shouldCreateUser: true,
         },
       })

--- a/components/login-dialog.tsx
+++ b/components/login-dialog.tsx
@@ -28,10 +28,12 @@ export function LoginDialog({ open, onOpenChange, onLoginSuccess }: LoginDialogP
   const handleGoogleSignIn = async () => {
     try {
       setIsLoading(true)
+      const next = `${window.location.pathname}${window.location.search}`
+      const redirectUrl = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`
       await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: `${window.location.origin}/auth/callback`,
+          redirectTo: redirectUrl,
         },
       })
       // No podemos llamar a onLoginSuccess aquí porque la redirección ocurre antes
@@ -53,10 +55,12 @@ export function LoginDialog({ open, onOpenChange, onLoginSuccess }: LoginDialogP
 
     setIsLoading(true)
     try {
+      const next = `${window.location.pathname}${window.location.search}`
+      const redirectUrl = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          emailRedirectTo: redirectUrl,
           shouldCreateUser: true,
         },
       })
@@ -98,10 +102,12 @@ export function LoginDialog({ open, onOpenChange, onLoginSuccess }: LoginDialogP
 
     setIsLoading(true)
     try {
+      const next = `${window.location.pathname}${window.location.search}`
+      const redirectUrl = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          emailRedirectTo: redirectUrl,
           shouldCreateUser: true,
         },
       })


### PR DESCRIPTION
## Summary
- preserve the page that triggered login and include it in the Supabase redirect URL
- send that destination to Supabase when signing in from `AuthForm` and `LoginDialog`
- update auth callback to redirect to that page after successful authentication

## Testing
- `npx jest` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419b8735f883279ec1fd577e8712e1