### PR TITLE
Add UTM helper and update book links

### DIFF
--- a/__tests__/lib/utm.test.ts
+++ b/__tests__/lib/utm.test.ts
@@ -1,0 +1,15 @@
+import { addUtmParams } from "@/lib/utm"
+
+describe("addUtmParams", () => {
+  test("adds utm parameters to url without query", () => {
+    expect(addUtmParams("https://example.com")).toBe(
+      "https://example.com/?utm_source=mi_libro&utm_medium=landing&utm_campaign=renuncio"
+    )
+  })
+
+  test("merges utm parameters with existing query", () => {
+    expect(addUtmParams("https://example.com/path?foo=bar")).toBe(
+      "https://example.com/path?foo=bar&utm_source=mi_libro&utm_medium=landing&utm_campaign=renuncio"
+    )
+  })
+})

--- a/app/mi-libro/page.tsx
+++ b/app/mi-libro/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { ExternalLink, BookOpen, Globe, Smartphone } from "lucide-react"
+import { addUtmParams } from "@/lib/utm"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
@@ -90,7 +91,9 @@ export default function MiLibroPage() {
                   <div className="space-y-3 flex-grow">
                     <Button asChild className="w-full bg-orange-600 hover:bg-orange-700">
                       <Link
-                        href="https://www.galernaweb.com/productos/renuncio-eliana-bracciaforte/"
+                        href={addUtmParams(
+                          "https://www.galernaweb.com/productos/renuncio-eliana-bracciaforte/"
+                        )}
                         target="_blank"
                         rel="noopener noreferrer"
                       >
@@ -100,14 +103,20 @@ export default function MiLibroPage() {
                       </Link>
                     </Button>
                     <Button asChild variant="outline" className="w-full">
-                      <Link href="https://cuspide.com/producto/renuncio/" target="_blank" rel="noopener noreferrer">
+                      <Link
+                        href={addUtmParams("https://cuspide.com/producto/renuncio/")}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
                         🛍️ Cúspide
                         <ExternalLink className="ml-2 h-4 w-4" />
                       </Link>
                     </Button>
                     <Button asChild variant="outline" className="w-full">
                       <Link
-                        href="https://www.yenny-elateneo.com/productos/renuncio/"
+                        href={addUtmParams(
+                          "https://www.yenny-elateneo.com/productos/renuncio/"
+                        )}
                         target="_blank"
                         rel="noopener noreferrer"
                       >
@@ -129,7 +138,9 @@ export default function MiLibroPage() {
                   <div className="space-y-3 flex-grow">
                     <Button asChild className="w-full bg-blue-600 hover:bg-blue-700">
                       <Link
-                        href="https://www.buscalibre.com.ar/libro-renuncio/9786316632524/p/64318014"
+                        href={addUtmParams(
+                          "https://www.buscalibre.com.ar/libro-renuncio/9786316632524/p/64318014"
+                        )}
                         target="_blank"
                         rel="noopener noreferrer"
                       >
@@ -151,7 +162,9 @@ export default function MiLibroPage() {
                   <div className="space-y-3 flex-grow">
                     <Button asChild className="w-full bg-purple-600 hover:bg-purple-700">
                       <Link
-                        href="https://www.amazon.com/Renuncio-Cambiar-trabajo-recuperar-Spanish-ebook/dp/B0FC364QY4/"
+                        href={addUtmParams(
+                          "https://www.amazon.com/Renuncio-Cambiar-trabajo-recuperar-Spanish-ebook/dp/B0FC364QY4/"
+                        )}
                         target="_blank"
                         rel="noopener noreferrer"
                       >
@@ -161,7 +174,9 @@ export default function MiLibroPage() {
                     </Button>
                     <Button asChild variant="outline" className="w-full">
                       <Link
-                        href="https://books.google.com.ar/books?id=A6xjEQAAQBAJ&newbks=0&lpg=PT29&dq=renuncio%20cambiar%20de%20trabajo%20y%20recuperar%20tu%20vida&pg=PA1#v=onepage&q&f=false"
+                        href={addUtmParams(
+                          "https://books.google.com.ar/books?id=A6xjEQAAQBAJ&newbks=0&lpg=PT29&dq=renuncio%20cambiar%20de%20trabajo%20y%20recuperar%20tu%20vida&pg=PA1#v=onepage&q&f=false"
+                        )}
                         target="_blank"
                         rel="noopener noreferrer"
                       >
@@ -235,7 +250,9 @@ export default function MiLibroPage() {
                 <div className="flex flex-col sm:flex-row gap-4 justify-center">
                   <Button asChild size="lg" className="bg-white text-orange-600 hover:bg-gray-100">
                     <Link
-                      href="https://www.galernaweb.com/productos/renuncio-eliana-bracciaforte/"
+                      href={addUtmParams(
+                        "https://www.galernaweb.com/productos/renuncio-eliana-bracciaforte/"
+                      )}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -246,7 +263,9 @@ export default function MiLibroPage() {
                   </Button>
                   <Button asChild size="lg" className="bg-white text-purple-600 hover:bg-gray-100">
                     <Link
-                      href="https://www.amazon.com/Renuncio-Cambiar-trabajo-recuperar-Spanish-ebook/dp/B0FC364QY4/"
+                      href={addUtmParams(
+                        "https://www.amazon.com/Renuncio-Cambiar-trabajo-recuperar-Spanish-ebook/dp/B0FC364QY4/"
+                      )}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/lib/utm.ts
+++ b/lib/utm.ts
@@ -1,0 +1,7 @@
+export function addUtmParams(url: string): string {
+  const u = new URL(url)
+  u.searchParams.set("utm_source", "mi_libro")
+  u.searchParams.set("utm_medium", "landing")
+  u.searchParams.set("utm_campaign", "renuncio")
+  return u.toString()
+}


### PR DESCRIPTION
## Summary
- add `addUtmParams` helper for generating UTM tracking URLs
- create tests for the new UTM helper
- apply UTM parameters to external purchase links on the book landing page

## Testing
- `pnpm lint` *(fails: next not found)*
- `npx jest` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_684af7fd11c08327a2e3b809da8fd496