### PR TITLE
Fix jest config for next-themes

### DIFF
--- a/__mocks__/next-themes-mock.js
+++ b/__mocks__/next-themes-mock.js
@@ -1,0 +1,6 @@
+module.exports = {
+  useTheme: () => ({
+    theme: 'light',
+    setTheme: jest.fn(),
+  }),
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ const customJestConfig = {
     "^tailwindcss-animate$": "<rootDir>/__mocks__/tailwindcss-animate-mock.js",
     "^next/navigation$": "<rootDir>/__mocks__/next-navigation-mock.js",
     "^lucide-react$": "<rootDir>/__mocks__/lucide-react-mock.js",
+    "^next-themes$": "<rootDir>/__mocks__/next-themes-mock.js",
   },
   // Solo ejecutar pruebas en el directorio __tests__
   testMatch: ["**/__tests__/**/*.test.[jt]s?(x)"],


### PR DESCRIPTION
## Summary
- mock `next-themes` so tests can run without the real package

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859685fe6088327a64e79746d3dcab1