### PR TITLE
test: add clsx jest mock

### DIFF
--- a/__mocks__/clsx-mock.js
+++ b/__mocks__/clsx-mock.js
@@ -1,0 +1,2 @@
+const clsx = (...inputs) => inputs.filter(Boolean).join(' ')
+module.exports = { __esModule: true, default: clsx, clsx }

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ const customJestConfig = {
     "^@/(.*)$": "<rootDir>/$1",
     // Mocks para dependencias problemáticas
     "^class-variance-authority$": "<rootDir>/__mocks__/cva-mock.js",
+    "^clsx$": "<rootDir>/__mocks__/clsx-mock.js",
     "^@radix-ui/(.*)$": "<rootDir>/__mocks__/radix-mock.js",
     "^tailwindcss-animate$": "<rootDir>/__mocks__/tailwindcss-animate-mock.js",
     "^next/navigation$": "<rootDir>/__mocks__/next-navigation-mock.js",


### PR DESCRIPTION
## Summary
- mock `clsx` for the Jest test suite
- map `clsx` in `jest.config.js`

## Testing
- `npx jest __tests__/components/comment-form.test.tsx --runInBand` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68596895ff3c8327baaf31660861b4a7