### PR TITLE
Add jest mocks for uninstalled modules

### DIFF
--- a/__mocks__/date-fns-locale-mock.js
+++ b/__mocks__/date-fns-locale-mock.js
@@ -1,0 +1,3 @@
+module.exports = {
+  es: {},
+}

--- a/__mocks__/date-fns-mock.js
+++ b/__mocks__/date-fns-mock.js
@@ -1,0 +1,3 @@
+module.exports = {
+  formatDistanceToNow: () => '0 days',
+}

--- a/__mocks__/supabase-auth-helpers-nextjs-mock.js
+++ b/__mocks__/supabase-auth-helpers-nextjs-mock.js
@@ -1,0 +1,29 @@
+const { jest } = require('@jest/globals')
+
+module.exports = {
+  createServerActionClient: jest.fn(() => ({
+    auth: {
+      getSession: jest.fn().mockResolvedValue({
+        data: {
+          session: {
+            user: { id: 'test-user-id' },
+          },
+        },
+      }),
+      getUser: jest.fn().mockResolvedValue({ user: { id: 'test-user-id' } }),
+    },
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+      single: jest.fn().mockResolvedValue({ data: {}, error: null }),
+    })),
+    rpc: jest.fn(() => ({
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+  })),
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,9 @@ const customJestConfig = {
     "^next/navigation$": "<rootDir>/__mocks__/next-navigation-mock.js",
     "^lucide-react$": "<rootDir>/__mocks__/lucide-react-mock.js",
     "^next-themes$": "<rootDir>/__mocks__/next-themes-mock.js",
+    "^@supabase/auth-helpers-nextjs$": "<rootDir>/__mocks__/supabase-auth-helpers-nextjs-mock.js",
+    "^date-fns$": "<rootDir>/__mocks__/date-fns-mock.js",
+    "^date-fns/locale$": "<rootDir>/__mocks__/date-fns-locale-mock.js",
   },
   // Solo ejecutar pruebas en el directorio __tests__
   testMatch: ["**/__tests__/**/*.test.[jt]s?(x)"],


### PR DESCRIPTION
## Summary
- map missing libs in jest config
- mock Supabase auth helper
- mock DateFns

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596c87ee008327a0cff792002ce087