### PR TITLE
Enable caching and concurrent story fetch

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,13 +8,11 @@ import Link from "next/link"
 import { TagBadge } from "@/components/tag-badge"
 import { PendingSubmissionRedirect } from "@/components/pending-submission-redirect"
 
-// Forzar que esta ruta sea dinámica para evitar errores con cookies
-export const dynamic = "force-dynamic"
+export const revalidate = 60 // Revalidate every minute
 
 export default async function Home() {
-  // Obtener historias y etiquetas
-  const stories = await getStories()
-  const tags = await getAllTags()
+  // Obtener historias y etiquetas de forma concurrente
+  const [stories, tags] = await Promise.all([getStories(), getAllTags()])
 
   // Obtener conteo de comentarios para todas las historias
   const storyIds = stories.map((story) => story.id)


### PR DESCRIPTION
## Summary
- fetch stories and tags concurrently with `Promise.all`
- cache the home page with ISR via `export const revalidate = 60`

## Testing
- `npx jest` *(fails: 403 Forbidden due to offline environment)*
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebb7eb0508327a918283c511063b7