### PR TITLE
Remove unoptimized setting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,9 +6,6 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  images: {
-    unoptimized: true,
-  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- enable Next.js image optimization by removing `unoptimized` option

## Testing
- `npx jest` *(fails: 403 Forbidden while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_685ebb894268832784cdd6d8592a07c3